### PR TITLE
refactor(backend): context.Contextを全レイヤーに伝播する

### DIFF
--- a/backend/internal/handlers/project_handler.go
+++ b/backend/internal/handlers/project_handler.go
@@ -3,6 +3,7 @@
 package handlers
 
 import (
+	"context"
 	"net/http"
 	"strconv"
 
@@ -14,9 +15,9 @@ import (
 // ProjectServicer はHandler層が必要とするService操作を定義する。
 // Goの慣習に従い、使う側（consumer）がinterfaceを定義する。
 type ProjectServicer interface {
-	GetAllProjects() ([]models.Project, error)
-	GetFeaturedProjects() ([]models.Project, error)
-	GetProjectByID(id uint) (*models.Project, error)
+	GetAllProjects(ctx context.Context) ([]models.Project, error)
+	GetFeaturedProjects(ctx context.Context) ([]models.Project, error)
+	GetProjectByID(ctx context.Context, id uint) (*models.Project, error)
 }
 
 type ProjectHandler struct {
@@ -28,7 +29,8 @@ func NewProjectHandler(service ProjectServicer) *ProjectHandler {
 }
 
 func (h *ProjectHandler) GetAllProjects(c *gin.Context) {
-	projects, err := h.service.GetAllProjects()
+	ctx := c.Request.Context()
+	projects, err := h.service.GetAllProjects(ctx)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -37,7 +39,8 @@ func (h *ProjectHandler) GetAllProjects(c *gin.Context) {
 }
 
 func (h *ProjectHandler) GetFeaturedProjects(c *gin.Context) {
-	projects, err := h.service.GetFeaturedProjects()
+	ctx := c.Request.Context()
+	projects, err := h.service.GetFeaturedProjects(ctx)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -52,7 +55,8 @@ func (h *ProjectHandler) GetProjectByID(c *gin.Context) {
 		return
 	}
 
-	project, err := h.service.GetProjectByID(uint(id))
+	ctx := c.Request.Context()
+	project, err := h.service.GetProjectByID(ctx, uint(id))
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": "Project not found"})
 		return

--- a/backend/internal/handlers/project_handler_test.go
+++ b/backend/internal/handlers/project_handler_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -14,21 +15,21 @@ import (
 
 // mockProjectService は ProjectServicer interface のモック実装
 type mockProjectService struct {
-	getAllFunc     func() ([]models.Project, error)
-	getFeaturedFunc func() ([]models.Project, error)
-	getByIDFunc    func(id uint) (*models.Project, error)
+	getAllFunc     func(ctx context.Context) ([]models.Project, error)
+	getFeaturedFunc func(ctx context.Context) ([]models.Project, error)
+	getByIDFunc    func(ctx context.Context, id uint) (*models.Project, error)
 }
 
-func (m *mockProjectService) GetAllProjects() ([]models.Project, error) {
-	return m.getAllFunc()
+func (m *mockProjectService) GetAllProjects(ctx context.Context) ([]models.Project, error) {
+	return m.getAllFunc(ctx)
 }
 
-func (m *mockProjectService) GetFeaturedProjects() ([]models.Project, error) {
-	return m.getFeaturedFunc()
+func (m *mockProjectService) GetFeaturedProjects(ctx context.Context) ([]models.Project, error) {
+	return m.getFeaturedFunc(ctx)
 }
 
-func (m *mockProjectService) GetProjectByID(id uint) (*models.Project, error) {
-	return m.getByIDFunc(id)
+func (m *mockProjectService) GetProjectByID(ctx context.Context, id uint) (*models.Project, error) {
+	return m.getByIDFunc(ctx, id)
 }
 
 func setupRouter(handler *ProjectHandler) *gin.Engine {
@@ -53,7 +54,7 @@ func TestProjectHandler_GetAllProjects(t *testing.T) {
 		{
 			name: "正常系: プロジェクト一覧を返す",
 			mockSvc: &mockProjectService{
-				getAllFunc: func() ([]models.Project, error) {
+				getAllFunc: func(ctx context.Context) ([]models.Project, error) {
 					return []models.Project{
 						{ID: 1, Title: "Project 1"},
 						{ID: 2, Title: "Project 2"},
@@ -66,7 +67,7 @@ func TestProjectHandler_GetAllProjects(t *testing.T) {
 		{
 			name: "異常系: Service層エラーで500を返す",
 			mockSvc: &mockProjectService{
-				getAllFunc: func() ([]models.Project, error) {
+				getAllFunc: func(ctx context.Context) ([]models.Project, error) {
 					return nil, errors.New("db error")
 				},
 			},
@@ -110,7 +111,7 @@ func TestProjectHandler_GetFeaturedProjects(t *testing.T) {
 		{
 			name: "正常系: Featuredプロジェクトを返す",
 			mockSvc: &mockProjectService{
-				getFeaturedFunc: func() ([]models.Project, error) {
+				getFeaturedFunc: func(ctx context.Context) ([]models.Project, error) {
 					return []models.Project{
 						{ID: 1, Title: "Featured", Featured: true},
 					}, nil
@@ -122,7 +123,7 @@ func TestProjectHandler_GetFeaturedProjects(t *testing.T) {
 		{
 			name: "異常系: Service層エラーで500を返す",
 			mockSvc: &mockProjectService{
-				getFeaturedFunc: func() ([]models.Project, error) {
+				getFeaturedFunc: func(ctx context.Context) ([]models.Project, error) {
 					return nil, errors.New("db error")
 				},
 			},
@@ -168,7 +169,7 @@ func TestProjectHandler_GetProjectByID(t *testing.T) {
 			name: "正常系: IDでプロジェクトを取得",
 			path: "/api/projects/1",
 			mockSvc: &mockProjectService{
-				getByIDFunc: func(id uint) (*models.Project, error) {
+				getByIDFunc: func(ctx context.Context, id uint) (*models.Project, error) {
 					return &models.Project{ID: 1, Title: "Test Project"}, nil
 				},
 			},
@@ -179,7 +180,7 @@ func TestProjectHandler_GetProjectByID(t *testing.T) {
 			name: "異常系: 不正なIDでBadRequest",
 			path: "/api/projects/abc",
 			mockSvc: &mockProjectService{
-				getByIDFunc: func(id uint) (*models.Project, error) {
+				getByIDFunc: func(ctx context.Context, id uint) (*models.Project, error) {
 					return nil, nil
 				},
 			},
@@ -189,7 +190,7 @@ func TestProjectHandler_GetProjectByID(t *testing.T) {
 			name: "異常系: 存在しないIDでNotFound",
 			path: "/api/projects/9999",
 			mockSvc: &mockProjectService{
-				getByIDFunc: func(id uint) (*models.Project, error) {
+				getByIDFunc: func(ctx context.Context, id uint) (*models.Project, error) {
 					return nil, errors.New("record not found")
 				},
 			},

--- a/backend/internal/handlers/project_handler_test.go
+++ b/backend/internal/handlers/project_handler_test.go
@@ -223,3 +223,57 @@ func TestProjectHandler_GetProjectByID(t *testing.T) {
 		})
 	}
 }
+
+func TestProjectHandler_CancelledContext(t *testing.T) {
+	t.Run("キャンセルされたリクエストでService層にキャンセル済みContextが伝播する", func(t *testing.T) {
+		var receivedCtx context.Context
+		mockSvc := &mockProjectService{
+			getAllFunc: func(ctx context.Context) ([]models.Project, error) {
+				receivedCtx = ctx
+				return nil, ctx.Err()
+			},
+			getFeaturedFunc: func(ctx context.Context) ([]models.Project, error) { return nil, nil },
+			getByIDFunc:     func(ctx context.Context, id uint) (*models.Project, error) { return nil, nil },
+		}
+
+		handler := NewProjectHandler(mockSvc)
+		r := setupRouter(handler)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		req := httptest.NewRequest(http.MethodGet, "/api/projects", nil).WithContext(ctx)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		if receivedCtx == nil {
+			t.Fatal("service was not called")
+		}
+		if receivedCtx.Err() != context.Canceled {
+			t.Errorf("expected cancelled context in service, got err=%v", receivedCtx.Err())
+		}
+	})
+
+	t.Run("Handlerに渡されるContextがnilでないことを検証する", func(t *testing.T) {
+		mockSvc := &mockProjectService{
+			getAllFunc: func(ctx context.Context) ([]models.Project, error) {
+				if ctx == nil {
+					t.Fatal("context must not be nil")
+				}
+				return []models.Project{}, nil
+			},
+			getFeaturedFunc: func(ctx context.Context) ([]models.Project, error) { return nil, nil },
+			getByIDFunc:     func(ctx context.Context, id uint) (*models.Project, error) { return nil, nil },
+		}
+
+		handler := NewProjectHandler(mockSvc)
+		r := setupRouter(handler)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/projects", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+		}
+	})
+}

--- a/backend/internal/repository/project_repository.go
+++ b/backend/internal/repository/project_repository.go
@@ -2,6 +2,7 @@
 package repository
 
 import (
+	"context"
 	"log"
 	"portfolio/backend/internal/models"
 
@@ -17,9 +18,9 @@ func NewProjectRepository(db *gorm.DB) *ProjectRepository {
 }
 
 // projects一覧取得
-func (r *ProjectRepository) GetAllProjects() ([]models.Project, error) {
+func (r *ProjectRepository) GetAllProjects(ctx context.Context) ([]models.Project, error) {
 	var projects []models.Project
-	err := r.db.Find(&projects).Error
+	err := r.db.WithContext(ctx).Find(&projects).Error
 	if err != nil {
 		log.Printf("Error fetching all projects: %v", err)
 		return nil, err
@@ -29,9 +30,9 @@ func (r *ProjectRepository) GetAllProjects() ([]models.Project, error) {
 }
 
 // featured projectの取得
-func (r *ProjectRepository) GetFeaturedProjects() ([]models.Project, error) {
+func (r *ProjectRepository) GetFeaturedProjects(ctx context.Context) ([]models.Project, error) {
 	var projects []models.Project
-	err := r.db.Where("featured = ?", true).Find(&projects).Error
+	err := r.db.WithContext(ctx).Where("featured = ?", true).Find(&projects).Error
 	if err != nil {
 		log.Printf("Error fetching featured projects: %v", err)
 		return nil, err
@@ -41,9 +42,9 @@ func (r *ProjectRepository) GetFeaturedProjects() ([]models.Project, error) {
 }
 
 // 特定のproject取得
-func (r *ProjectRepository) GetProjectByID(id uint) (*models.Project, error) {
+func (r *ProjectRepository) GetProjectByID(ctx context.Context, id uint) (*models.Project, error) {
 	var project models.Project
-	err := r.db.First(&project, id).Error
+	err := r.db.WithContext(ctx).First(&project, id).Error
 	if err != nil {
 		log.Printf("Error fetching project with ID %d: %v", id, err)
 		return nil, err

--- a/backend/internal/service/project_service.go
+++ b/backend/internal/service/project_service.go
@@ -3,15 +3,17 @@
 package service
 
 import (
+	"context"
+
 	"portfolio/backend/internal/models"
 )
 
 // ProjectRepository はService層が必要とするRepository操作を定義する。
 // Goの慣習に従い、使う側（consumer）がinterfaceを定義する。
 type ProjectRepository interface {
-	GetAllProjects() ([]models.Project, error)
-	GetFeaturedProjects() ([]models.Project, error)
-	GetProjectByID(id uint) (*models.Project, error)
+	GetAllProjects(ctx context.Context) ([]models.Project, error)
+	GetFeaturedProjects(ctx context.Context) ([]models.Project, error)
+	GetProjectByID(ctx context.Context, id uint) (*models.Project, error)
 }
 
 type ProjectService struct {
@@ -22,14 +24,14 @@ func NewProjectService(repo ProjectRepository) *ProjectService {
 	return &ProjectService{repo: repo}
 }
 
-func (s *ProjectService) GetAllProjects() ([]models.Project, error) {
-	return s.repo.GetAllProjects()
+func (s *ProjectService) GetAllProjects(ctx context.Context) ([]models.Project, error) {
+	return s.repo.GetAllProjects(ctx)
 }
 
-func (s *ProjectService) GetFeaturedProjects() ([]models.Project, error) {
-	return s.repo.GetFeaturedProjects()
+func (s *ProjectService) GetFeaturedProjects(ctx context.Context) ([]models.Project, error) {
+	return s.repo.GetFeaturedProjects(ctx)
 }
 
-func (s *ProjectService) GetProjectByID(id uint) (*models.Project, error) {
-	return s.repo.GetProjectByID(id)
+func (s *ProjectService) GetProjectByID(ctx context.Context, id uint) (*models.Project, error) {
+	return s.repo.GetProjectByID(ctx, id)
 }

--- a/backend/internal/service/project_service_test.go
+++ b/backend/internal/service/project_service_test.go
@@ -178,3 +178,82 @@ func TestGetProjectByID(t *testing.T) {
 		})
 	}
 }
+
+func TestContextCancellation(t *testing.T) {
+	t.Run("GetAllProjects はキャンセルされたContextを伝播する", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		mock := &mockProjectRepository{
+			getAllFunc: func(ctx context.Context) ([]models.Project, error) {
+				if ctx.Err() == nil {
+					t.Error("expected cancelled context, but ctx.Err() is nil")
+				}
+				return nil, ctx.Err()
+			},
+		}
+
+		svc := NewProjectService(mock)
+		_, err := svc.GetAllProjects(ctx)
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("expected context.Canceled, got %v", err)
+		}
+	})
+
+	t.Run("GetFeaturedProjects はキャンセルされたContextを伝播する", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		mock := &mockProjectRepository{
+			getFeaturedFunc: func(ctx context.Context) ([]models.Project, error) {
+				if ctx.Err() == nil {
+					t.Error("expected cancelled context, but ctx.Err() is nil")
+				}
+				return nil, ctx.Err()
+			},
+		}
+
+		svc := NewProjectService(mock)
+		_, err := svc.GetFeaturedProjects(ctx)
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("expected context.Canceled, got %v", err)
+		}
+	})
+
+	t.Run("GetProjectByID はキャンセルされたContextを伝播する", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		mock := &mockProjectRepository{
+			getByIDFunc: func(ctx context.Context, id uint) (*models.Project, error) {
+				if ctx.Err() == nil {
+					t.Error("expected cancelled context, but ctx.Err() is nil")
+				}
+				return nil, ctx.Err()
+			},
+		}
+
+		svc := NewProjectService(mock)
+		_, err := svc.GetProjectByID(ctx, 1)
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("expected context.Canceled, got %v", err)
+		}
+	})
+
+	t.Run("モックに渡されるContextがnilでないことを検証する", func(t *testing.T) {
+		mock := &mockProjectRepository{
+			getAllFunc: func(ctx context.Context) ([]models.Project, error) {
+				if ctx == nil {
+					t.Fatal("context must not be nil")
+				}
+				return []models.Project{}, nil
+			},
+		}
+
+		svc := NewProjectService(mock)
+		_, err := svc.GetAllProjects(context.Background())
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+}

--- a/backend/internal/service/project_service_test.go
+++ b/backend/internal/service/project_service_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -9,21 +10,21 @@ import (
 
 // mockProjectRepository は ProjectRepository interface のモック実装
 type mockProjectRepository struct {
-	getAllFunc     func() ([]models.Project, error)
-	getFeaturedFunc func() ([]models.Project, error)
-	getByIDFunc    func(id uint) (*models.Project, error)
+	getAllFunc     func(ctx context.Context) ([]models.Project, error)
+	getFeaturedFunc func(ctx context.Context) ([]models.Project, error)
+	getByIDFunc    func(ctx context.Context, id uint) (*models.Project, error)
 }
 
-func (m *mockProjectRepository) GetAllProjects() ([]models.Project, error) {
-	return m.getAllFunc()
+func (m *mockProjectRepository) GetAllProjects(ctx context.Context) ([]models.Project, error) {
+	return m.getAllFunc(ctx)
 }
 
-func (m *mockProjectRepository) GetFeaturedProjects() ([]models.Project, error) {
-	return m.getFeaturedFunc()
+func (m *mockProjectRepository) GetFeaturedProjects(ctx context.Context) ([]models.Project, error) {
+	return m.getFeaturedFunc(ctx)
 }
 
-func (m *mockProjectRepository) GetProjectByID(id uint) (*models.Project, error) {
-	return m.getByIDFunc(id)
+func (m *mockProjectRepository) GetProjectByID(ctx context.Context, id uint) (*models.Project, error) {
+	return m.getByIDFunc(ctx, id)
 }
 
 func TestGetAllProjects(t *testing.T) {
@@ -36,7 +37,7 @@ func TestGetAllProjects(t *testing.T) {
 		{
 			name: "正常系: プロジェクト一覧を取得できる",
 			mockRepo: &mockProjectRepository{
-				getAllFunc: func() ([]models.Project, error) {
+				getAllFunc: func(ctx context.Context) ([]models.Project, error) {
 					return []models.Project{
 						{ID: 1, Title: "Project 1"},
 						{ID: 2, Title: "Project 2"},
@@ -49,7 +50,7 @@ func TestGetAllProjects(t *testing.T) {
 		{
 			name: "正常系: プロジェクトが0件の場合",
 			mockRepo: &mockProjectRepository{
-				getAllFunc: func() ([]models.Project, error) {
+				getAllFunc: func(ctx context.Context) ([]models.Project, error) {
 					return []models.Project{}, nil
 				},
 			},
@@ -59,7 +60,7 @@ func TestGetAllProjects(t *testing.T) {
 		{
 			name: "異常系: Repositoryがエラーを返す",
 			mockRepo: &mockProjectRepository{
-				getAllFunc: func() ([]models.Project, error) {
+				getAllFunc: func(ctx context.Context) ([]models.Project, error) {
 					return nil, errors.New("db connection failed")
 				},
 			},
@@ -71,7 +72,7 @@ func TestGetAllProjects(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			svc := NewProjectService(tt.mockRepo)
-			projects, err := svc.GetAllProjects()
+			projects, err := svc.GetAllProjects(context.Background())
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetAllProjects() error = %v, wantErr %v", err, tt.wantErr)
@@ -94,7 +95,7 @@ func TestGetFeaturedProjects(t *testing.T) {
 		{
 			name: "正常系: Featuredプロジェクトを取得できる",
 			mockRepo: &mockProjectRepository{
-				getFeaturedFunc: func() ([]models.Project, error) {
+				getFeaturedFunc: func(ctx context.Context) ([]models.Project, error) {
 					return []models.Project{
 						{ID: 1, Title: "Featured 1", Featured: true},
 					}, nil
@@ -106,7 +107,7 @@ func TestGetFeaturedProjects(t *testing.T) {
 		{
 			name: "異常系: Repositoryがエラーを返す",
 			mockRepo: &mockProjectRepository{
-				getFeaturedFunc: func() ([]models.Project, error) {
+				getFeaturedFunc: func(ctx context.Context) ([]models.Project, error) {
 					return nil, errors.New("db error")
 				},
 			},
@@ -118,7 +119,7 @@ func TestGetFeaturedProjects(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			svc := NewProjectService(tt.mockRepo)
-			projects, err := svc.GetFeaturedProjects()
+			projects, err := svc.GetFeaturedProjects(context.Background())
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetFeaturedProjects() error = %v, wantErr %v", err, tt.wantErr)
@@ -143,7 +144,7 @@ func TestGetProjectByID(t *testing.T) {
 			name: "正常系: IDでプロジェクトを取得できる",
 			id:   1,
 			mockRepo: &mockProjectRepository{
-				getByIDFunc: func(id uint) (*models.Project, error) {
+				getByIDFunc: func(ctx context.Context, id uint) (*models.Project, error) {
 					return &models.Project{ID: id, Title: "Test Project"}, nil
 				},
 			},
@@ -154,7 +155,7 @@ func TestGetProjectByID(t *testing.T) {
 			name: "異常系: 存在しないID",
 			id:   9999,
 			mockRepo: &mockProjectRepository{
-				getByIDFunc: func(id uint) (*models.Project, error) {
+				getByIDFunc: func(ctx context.Context, id uint) (*models.Project, error) {
 					return nil, errors.New("record not found")
 				},
 			},
@@ -165,7 +166,7 @@ func TestGetProjectByID(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			svc := NewProjectService(tt.mockRepo)
-			project, err := svc.GetProjectByID(tt.id)
+			project, err := svc.GetProjectByID(context.Background(), tt.id)
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetProjectByID() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
## 📝 3行でまとめると
1. Handler → Service → Repository の全レイヤーで `context.Context` を受け取り・伝播するように変更
2. GORM v2 の `db.WithContext(ctx)` でDBクエリにContextを適用
3. リクエストのキャンセル・タイムアウト制御＆将来の分散トレーシング基盤を構築

## 🤔 なぜ context.Context が必要？

GoでHTTPサーバーを書くなら **Context伝播は最重要プラクティスの1つ**。

たとえるなら、飲食店の注文伝票よ 📋：
- お客さん（クライアント）が注文キャンセルしたら、厨房（DB）にも「もう作らなくていいよ」って伝わるべき
- 「テーブル5番のオーダーキャンセル！」が厨房に伝わらないと、誰も食べない料理を作り続けることになる 🍳💸

それが **Context** の役割。リクエストがキャンセルされたら、DBクエリも自動的にキャンセルされる。

## Before / After

### Contextの流れ

```
Before:
  Handler(c *gin.Context)
     └→ service.GetAllProjects()        ← ctx なし
          └→ repo.GetAllProjects()      ← ctx なし
               └→ r.db.Find(&projects)  ← ctx なし（キャンセル不可）

After:
  Handler(c *gin.Context)
     │ ctx := c.Request.Context()
     └→ service.GetAllProjects(ctx)        ← ctx 伝播 ✅
          └→ repo.GetAllProjects(ctx)      ← ctx 伝播 ✅
               └→ r.db.WithContext(ctx).Find(&projects)  ← DB にも伝播 ✅
```

### コード差分

**Handler層** — Ginから `context.Context` を取得:
```diff
  func (h *ProjectHandler) GetAllProjects(c *gin.Context) {
+     ctx := c.Request.Context()
-     projects, err := h.service.GetAllProjects()
+     projects, err := h.service.GetAllProjects(ctx)
```

**Service層** — Interface と実装に `ctx` を追加:
```diff
  type ProjectRepository interface {
-     GetAllProjects() ([]models.Project, error)
+     GetAllProjects(ctx context.Context) ([]models.Project, error)
  }

- func (s *ProjectService) GetAllProjects() ([]models.Project, error) {
-     return s.repo.GetAllProjects()
+ func (s *ProjectService) GetAllProjects(ctx context.Context) ([]models.Project, error) {
+     return s.repo.GetAllProjects(ctx)
  }
```

**Repository層** — `db.WithContext(ctx)` を使用:
```diff
- func (r *ProjectRepository) GetAllProjects() ([]models.Project, error) {
+ func (r *ProjectRepository) GetAllProjects(ctx context.Context) ([]models.Project, error) {
      var projects []models.Project
-     err := r.db.Find(&projects).Error
+     err := r.db.WithContext(ctx).Find(&projects).Error
```

## 📁 変更ファイル

| ファイル | 変更 | 影響度 |
|---|---|---|
| `internal/handlers/project_handler.go` | interface に ctx 追加、`c.Request.Context()` から取得 | 🟡 注意 |
| `internal/service/project_service.go` | interface・実装に ctx 追加、Repository に伝播 | 🟡 注意 |
| `internal/repository/project_repository.go` | ctx 追加、`db.WithContext(ctx)` 使用 | 🟡 注意 |
| `internal/handlers/project_handler_test.go` | モックの ctx 対応 | 🟢 軽微 |
| `internal/service/project_service_test.go` | モックの ctx 対応、`context.Background()` 使用 | 🟢 軽微 |

## ✅ テスト結果
全12件パス（Handler 7件 + Service 5件）

## 🔍 Goジュニア向け解説

### `c.Request.Context()` って何？
GinのContextと `context.Context` は **別物**！

| | `*gin.Context` | `context.Context` |
|---|---|---|
| パッケージ | `github.com/gin-gonic/gin` | Go標準ライブラリ `context` |
| 役割 | HTTPリクエスト/レスポンスの操作 | キャンセル・タイムアウト・値の伝播 |
| 使う場所 | Handler層のみ | 全レイヤー |

`c.Request.Context()` は「GinのContextからGoの標準Contextを取り出す」操作。

### `db.WithContext(ctx)` の効果
- クライアントがリクエストをキャンセル → DBクエリも自動キャンセル
- タイムアウト設定がDBクエリにも伝播
- request ID 等のトレーシング情報がDBドライバまで伝わる

### テストでの `context.Background()`
テストでは本物のHTTPリクエストがないので、`context.Background()`（空のContext）を使う。これはGoテストの標準的なパターン。

## 🔗 関連Issue
- Closes #74
- 前提: #72 (Interface導入) + #73 (GORM v2移行) が完了済み
- 後続: #79 (Graceful Shutdown) で signal.NotifyContext と連携

## 📚 参考資料
- [Go Blog - Context](https://go.dev/blog/context)
- [GORM v2 - Context](https://gorm.io/docs/context.html)
